### PR TITLE
Add wp-env integration tests for Handbook plugin

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,9 +1,8 @@
 name: Unit Tests
 
 on:
-  push:
-    branches: [ trunk ]
   pull_request:
+  push:
     branches: [ trunk ]
 
 jobs:
@@ -51,3 +50,36 @@ jobs:
       - name: Run PHPUnit
         working-directory: ${{ matrix.working-directory }}
         run: phpunit ${{ matrix.phpunit-args }}
+
+  # WordPress-dependent PHP tests — require wp-env (Docker).
+  php-wordpress:
+    name: "WP: ${{ matrix.name }}"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Handbook Plugin
+            plugin-directory: wordpress.org/public_html/wp-content/plugins/handbook
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install wp-env
+        run: npm -g install @wordpress/env
+
+      - name: Start wp-env
+        working-directory: ${{ matrix.plugin-directory }}
+        run: wp-env start
+
+      - name: Install PHPUnit Polyfills
+        working-directory: ${{ matrix.plugin-directory }}
+        run: wp-env run tests-cli composer require --dev yoast/phpunit-polyfills:^4.0 --working-dir=/wordpress-phpunit
+
+      - name: Run PHPUnit
+        working-directory: ${{ matrix.plugin-directory }}
+        run: wp-env run tests-cli --env-cwd=wp-content/plugins/$(basename ${{ matrix.plugin-directory }}) phpunit --no-configuration --bootstrap phpunit/bootstrap.php phpunit/tests/

--- a/wordpress.org/public_html/wp-content/plugins/handbook/phpunit/bootstrap.php
+++ b/wordpress.org/public_html/wp-content/plugins/handbook/phpunit/bootstrap.php
@@ -14,6 +14,10 @@ $_tests_dir = getenv( 'WP_TESTS_DIR' );
 if ( ! $_tests_dir && false !== ( $pos = stripos( __FILE__, '/src/wp-content/plugins/' ) ) ) {
 	$_tests_dir = substr( __FILE__, 0, $pos ) . '/tests/phpunit/';
 }
+// Check for wp-env test directory.
+elseif ( ! $_tests_dir && file_exists( '/wordpress-phpunit/includes/functions.php' ) ) {
+	$_tests_dir = '/wordpress-phpunit/';
+}
 // Elseif no path yet, assume a temp directory path.
 elseif ( ! $_tests_dir ) {
 	$_tests_dir = rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress-tests-lib/tests/phpunit/';
@@ -22,6 +26,11 @@ elseif ( ! $_tests_dir ) {
 if ( ! file_exists( $_tests_dir . '/includes/functions.php' ) ) {
 	echo "Could not find $_tests_dir/includes/functions.php\n";
 	exit( 1 );
+}
+
+// Set polyfills path if available (required by WP test suite).
+if ( ! defined( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH' ) && file_exists( $_tests_dir . '/vendor/yoast/phpunit-polyfills' ) ) {
+	define( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH', $_tests_dir . '/vendor/yoast/phpunit-polyfills' );
 }
 
 // Give access to tests_add_filter() function.

--- a/wordpress.org/public_html/wp-content/plugins/handbook/phpunit/tests/handbook.php
+++ b/wordpress.org/public_html/wp-content/plugins/handbook/phpunit/tests/handbook.php
@@ -17,7 +17,7 @@ class WPorg_Handbook_Handbook_Test extends WP_UnitTestCase {
 
 	protected $handbook;
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setup();
 		WPorg_Handbook_Init::init();
 
@@ -25,7 +25,7 @@ class WPorg_Handbook_Handbook_Test extends WP_UnitTestCase {
 		$this->handbook = reset( $handbooks );
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 
 		foreach ( WPorg_Handbook_Init::get_handbook_objects() as $obj ) {
@@ -455,7 +455,7 @@ class WPorg_Handbook_Handbook_Test extends WP_UnitTestCase {
 
 		$this->assertTrue( isset( $wp_registered_sidebars[ 'handbook' ] ) );
 		$this->assertSame(
-			[ 'name', 'id', 'description', 'class', 'before_widget', 'after_widget', 'before_title', 'after_title', 'before_sidebar', 'after_sidebar' ],
+			[ 'name', 'id', 'description', 'class', 'before_widget', 'after_widget', 'before_title', 'after_title', 'before_sidebar', 'after_sidebar', 'show_in_rest' ],
 			array_keys( $wp_registered_sidebars[ 'handbook' ] )
 		);
 		$this->assertEquals( 'handbook', $wp_registered_sidebars[ 'handbook' ]['id'] );

--- a/wordpress.org/public_html/wp-content/plugins/handbook/phpunit/tests/init.php
+++ b/wordpress.org/public_html/wp-content/plugins/handbook/phpunit/tests/init.php
@@ -4,13 +4,13 @@ defined( 'ABSPATH' ) or die();
 
 class WPorg_Handbook_Init_Test extends WP_UnitTestCase {
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setup();
 
 		WPorg_Handbook_Init::init();
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 
 		WPorg_Handbook_Init::reset( true );

--- a/wordpress.org/public_html/wp-content/plugins/handbook/phpunit/tests/template-tags.php
+++ b/wordpress.org/public_html/wp-content/plugins/handbook/phpunit/tests/template-tags.php
@@ -4,13 +4,13 @@ defined( 'ABSPATH' ) or die();
 
 class WPorg_Handbook_Template_Tags_Test extends WP_UnitTestCase {
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setup();
 
 		WPorg_Handbook_Init::init();
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 
 		WPorg_Handbook_Init::reset( true );


### PR DESCRIPTION
## Summary
- Adds wp-env-based CI job for Handbook plugin integration tests
- Adds wp-env path fallback to Handbook bootstrap (`/wordpress-phpunit/`)
- Adds `void` return types to `setUp()`/`tearDown()` for PHPUnit 9+ compatibility
- Updates sidebar assertion for WordPress `show_in_rest` key
- Includes the standalone PHP tests workflow from #5

## Test plan
- [ ] All standalone PHP tests pass
- [ ] Handbook wp-env integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)