### PR TITLE
Plugin Directory: Delay trunk-only imports on tag-releasing plugins

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-svn-watcher.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-svn-watcher.php
@@ -155,8 +155,10 @@ class SVN_Watcher {
 		
 				}
 
-				// This will have false-positives for when a readme in a subdirectory is hit, but this is only for optimizations.
-				if ( in_array( strtolower( basename( $path ) ), array( 'readme.txt', 'readme.md' ) ) ) {
+				// Only count the readme at the top level of /trunk or /tags/X.Y as the plugin's readme — a readme.txt in a subdirectory is just bundled documentation.
+				$is_top_level_in_trunk = ( 'trunk' === $path_parts[1] && isset( $path_parts[2] ) && ! isset( $path_parts[3] ) );
+				$is_top_level_in_tag   = ( 'tags' === $path_parts[1] && isset( $path_parts[3] ) && ! isset( $path_parts[4] ) );
+				if ( ( $is_top_level_in_trunk || $is_top_level_in_tag ) && in_array( strtolower( basename( $path ) ), array( 'readme.txt', 'readme.md' ) ) ) {
 					$plugin['readme_touched'] = true;
 				}
 				if ( ! $plugin['code_touched'] && ( '/' === substr( $path, -1 ) || '.php' === substr( $path, -4 ) || '.js' === substr( $path, -3 ) ) ) {

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-svn-watcher.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-svn-watcher.php
@@ -155,10 +155,8 @@ class SVN_Watcher {
 		
 				}
 
-				// Only count the readme at the top level of /trunk or /tags/X.Y as the plugin's readme — a readme.txt in a subdirectory is just bundled documentation.
-				$is_top_level_in_trunk = ( 'trunk' === $path_parts[1] && isset( $path_parts[2] ) && ! isset( $path_parts[3] ) );
-				$is_top_level_in_tag   = ( 'tags' === $path_parts[1] && isset( $path_parts[3] ) && ! isset( $path_parts[4] ) );
-				if ( ( $is_top_level_in_trunk || $is_top_level_in_tag ) && in_array( strtolower( basename( $path ) ), array( 'readme.txt', 'readme.md' ) ) ) {
+				// Only count the readme at the root of /trunk or a tag — a readme.txt in a subdirectory is just bundled documentation.
+				if ( preg_match( '!/(trunk|tags/[^/]+)/readme\.(txt|md)$!i', $path ) ) {
 					$plugin['readme_touched'] = true;
 				}
 				if ( ! $plugin['code_touched'] && ( '/' === substr( $path, -1 ) || '.php' === substr( $path, -4 ) || '.js' === substr( $path, -3 ) ) ) {

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-plugin-import.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-plugin-import.php
@@ -3,6 +3,8 @@ namespace WordPressdotorg\Plugin_Directory\Jobs;
 
 use Exception;
 use WordPressdotorg\Plugin_Directory\CLI;
+use WordPressdotorg\Plugin_Directory\Plugin_Directory;
+use WordPressdotorg\Plugin_Directory\Readme\Parser as Readme_Parser;
 
 /**
  * Import plugin changes into WordPress.
@@ -44,7 +46,7 @@ class Plugin_Import {
 				"import_plugin:{$plugin_slug}",
 				$next_scheduled,
 				array(
-					'nextrun' => min( $next_scheduled, self::queue_run_time( $merged_args ) ),
+					'nextrun' => min( $next_scheduled, self::queue_run_time( $plugin_slug, $merged_args ) ),
 					'args'    => array( $merged_args ),
 				)
 			);
@@ -54,7 +56,7 @@ class Plugin_Import {
 			}
 		}
 
-		$when_to_run = self::queue_run_time( $new_args );
+		$when_to_run = self::queue_run_time( $plugin_slug, $new_args );
 
 		// To avoid a situation where two imports run concurrently, if one is already scheduled or in flight, run it 1hr later (we'll trigger it after the current one finishes).
 		$last_scheduled = Manager::get_scheduled_time( "import_plugin:{$plugin_slug}", 'last' );
@@ -78,19 +80,28 @@ class Plugin_Import {
 	 * first and then `svn cp trunk tags/X.Y` a moment later. Running the import
 	 * immediately on the trunk commit publishes a trunk-fallback release that
 	 * the follow-up tag commit then re-publishes from the tag. To collapse the
-	 * two into one import, all trunk-only updates are deferred by 15 minutes —
-	 * that gives the follow-up tag commit time to merge into the same job (see
+	 * two into one import, trunk-only updates are deferred by 15 minutes — that
+	 * gives the follow-up tag commit time to merge into the same job (see
 	 * queue()). Tag-touching changes (additions or deletions) run immediately.
 	 *
-	 * @param array $args The args for the import job (post-merge where applicable).
+	 * The grace window is bypassed when the only change is a `Stable Tag` flip
+	 * in /trunk/readme.txt pointing at a tag that already exists in /tags/:
+	 * there's no follow-up tag to wait for in that case.
+	 *
+	 * @param string $plugin_slug The plugin slug.
+	 * @param array  $args        The args for the import job (post-merge where applicable).
 	 * @return int Unix timestamp for when the event should run.
 	 */
-	protected static function queue_run_time( $args ) {
-		if ( self::is_trunk_only_update( $args ) ) {
-			return time() + 15 * MINUTE_IN_SECONDS;
+	protected static function queue_run_time( $plugin_slug, $args ) {
+		if ( ! self::is_trunk_only_update( $args ) ) {
+			return time() + 5;
 		}
 
-		return time() + 5;
+		if ( ! empty( $args['readme_touched'] ) && self::trunk_stable_tag_flip_to_existing_tag( $plugin_slug ) ) {
+			return time() + 5;
+		}
+
+		return time() + 15 * MINUTE_IN_SECONDS;
 	}
 
 	/**
@@ -104,6 +115,39 @@ class Plugin_Import {
 		$tags_deleted = (array) ( $args['tags_deleted'] ?? array() );
 
 		return $tags_touched && array( 'trunk' ) === array_values( array_unique( $tags_touched ) ) && ! $tags_deleted;
+	}
+
+	/**
+	 * Whether /trunk/readme.txt's Stable Tag points to a tag that's already in
+	 * /tags/ AND differs from the directory's current stable_tag.
+	 *
+	 * Indicates a release-by-readme-flip — the author isn't going to follow up
+	 * with `svn cp trunk tags/X.Y` because the tag already exists. Used to skip
+	 * the 15-minute trunk grace window in that case.
+	 *
+	 * @param string $plugin_slug The plugin slug.
+	 * @return bool
+	 */
+	protected static function trunk_stable_tag_flip_to_existing_tag( $plugin_slug ) {
+		$plugin = Plugin_Directory::get_plugin_post( $plugin_slug );
+		if ( ! $plugin ) {
+			return false;
+		}
+
+		$readme         = new Readme_Parser( "https://plugins.svn.wordpress.org/{$plugin_slug}/trunk/readme.txt" );
+		$new_stable_tag = $readme->stable_tag;
+
+		if ( ! $new_stable_tag || 'trunk' === $new_stable_tag ) {
+			return false;
+		}
+
+		if ( get_post_meta( $plugin->ID, 'stable_tag', true ) === $new_stable_tag ) {
+			return false;
+		}
+
+		$tagged_versions = (array) get_post_meta( $plugin->ID, 'tagged_versions', true );
+
+		return in_array( $new_stable_tag, $tagged_versions, true );
 	}
 
 	/**

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-plugin-import.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-plugin-import.php
@@ -19,7 +19,6 @@ class Plugin_Import {
 	 * @param array  $plugin_data Data about the SVN change (tags_touched, revisions, etc).
 	 */
 	public static function queue( $plugin_slug, $plugin_data ) {
-		$hook     = "import_plugin:{$plugin_slug}";
 		$new_args = array_merge( array( 'plugin' => $plugin_slug ), $plugin_data );
 
 		/*
@@ -35,14 +34,14 @@ class Plugin_Import {
 		 *    it so a single import publishes from the tag, not from a trunk
 		 *    fallback that the tag commit then has to overwrite.
 		 */
-		$next_scheduled = Manager::get_scheduled_time( $hook, 'next' );
-		if ( $next_scheduled && ! Manager::is_event_running( $hook ) ) {
-			$existing      = Manager::get_scheduled_events( $hook, $next_scheduled );
+		$next_scheduled = Manager::get_scheduled_time( "import_plugin:{$plugin_slug}", 'next' );
+		if ( $next_scheduled && ! Manager::is_event_running( "import_plugin:{$plugin_slug}" ) ) {
+			$existing      = Manager::get_scheduled_events( "import_plugin:{$plugin_slug}", $next_scheduled );
 			$existing_args = $existing[0]['args'][0] ?? array();
 			$merged_args   = self::merge_plugin_data( $existing_args, $new_args );
 
 			$updated = Manager::update_scheduled_event(
-				$hook,
+				"import_plugin:{$plugin_slug}",
 				$next_scheduled,
 				array(
 					'nextrun' => min( $next_scheduled, self::queue_run_time( $merged_args ) ),
@@ -58,16 +57,16 @@ class Plugin_Import {
 		$when_to_run = self::queue_run_time( $new_args );
 
 		// To avoid a situation where two imports run concurrently, if one is already scheduled or in flight, run it 1hr later (we'll trigger it after the current one finishes).
-		$last_scheduled = Manager::get_scheduled_time( $hook, 'last' );
+		$last_scheduled = Manager::get_scheduled_time( "import_plugin:{$plugin_slug}", 'last' );
 		if ( $last_scheduled ) {
 			$when_to_run = $last_scheduled + HOUR_IN_SECONDS;
-		} elseif ( Manager::is_event_running( $hook ) ) {
+		} elseif ( Manager::is_event_running( "import_plugin:{$plugin_slug}" ) ) {
 			$when_to_run = time() + HOUR_IN_SECONDS;
 		}
 
 		wp_schedule_single_event(
 			$when_to_run,
-			$hook,
+			"import_plugin:{$plugin_slug}",
 			array( $new_args )
 		);
 	}

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-plugin-import.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-plugin-import.php
@@ -3,7 +3,6 @@ namespace WordPressdotorg\Plugin_Directory\Jobs;
 
 use Exception;
 use WordPressdotorg\Plugin_Directory\CLI;
-use WordPressdotorg\Plugin_Directory\Plugin_Directory;
 
 /**
  * Import plugin changes into WordPress.
@@ -30,10 +29,10 @@ class Plugin_Import {
 		 *
 		 *  - A bulk batch re-index queued an event far in the future; a fresh
 		 *    commit should pull that forward to the usual import time.
-		 *  - A plugin that releases from a tag commits to /trunk first and then
-		 *    `svn cp trunk tags/X.Y` a moment later (see queue_run_time()). The
-		 *    first commit gets delayed; the second merges into it so a single
-		 *    import publishes the release from the tag, not from a trunk
+		 *  - The 15-minute trunk grace window (see queue_run_time()): an author
+		 *    commits to /trunk first and then `svn cp trunk tags/X.Y` a moment
+		 *    later. The first commit's event is delayed; the second merges into
+		 *    it so a single import publishes from the tag, not from a trunk
 		 *    fallback that the tag commit then has to overwrite.
 		 */
 		$next_scheduled = Manager::get_scheduled_time( $hook, 'next' );
@@ -46,7 +45,7 @@ class Plugin_Import {
 				$hook,
 				$next_scheduled,
 				array(
-					'nextrun' => min( $next_scheduled, self::queue_run_time( $plugin_slug, $merged_args ) ),
+					'nextrun' => min( $next_scheduled, self::queue_run_time( $merged_args ) ),
 					'args'    => array( $merged_args ),
 				)
 			);
@@ -56,7 +55,7 @@ class Plugin_Import {
 			}
 		}
 
-		$when_to_run = self::queue_run_time( $plugin_slug, $new_args );
+		$when_to_run = self::queue_run_time( $new_args );
 
 		// To avoid a situation where two imports run concurrently, if one is already scheduled or in flight, run it 1hr later (we'll trigger it after the current one finishes).
 		$last_scheduled = Manager::get_scheduled_time( $hook, 'last' );
@@ -76,53 +75,36 @@ class Plugin_Import {
 	/**
 	 * Decide when an import job should run, based on the SVN changes it covers.
 	 *
-	 * Plugins that release from tags typically commit the version bump to /trunk
-	 * first and then `svn cp trunk tags/X.Y` shortly after. Running the import
-	 * immediately on the trunk commit publishes a trunk-fallback release that the
-	 * tag commit then has to overwrite as a second release. To collapse those
-	 * into one import, defer trunk-only updates by 5 minutes when the plugin is
-	 * currently releasing from a tag — that gives the follow-up tag commit time
-	 * to merge into the same job (see queue()).
+	 * Authors that release from a tag commonly commit the version bump to /trunk
+	 * first and then `svn cp trunk tags/X.Y` a moment later. Running the import
+	 * immediately on the trunk commit publishes a trunk-fallback release that
+	 * the follow-up tag commit then re-publishes from the tag. To collapse the
+	 * two into one import, all trunk-only updates are deferred by 15 minutes —
+	 * that gives the follow-up tag commit time to merge into the same job (see
+	 * queue()). Tag-touching changes (additions or deletions) run immediately.
 	 *
-	 * Tag-touching changes, and changes on plugins releasing from trunk, run
-	 * immediately.
-	 *
-	 * @param string $plugin_slug The plugin slug.
-	 * @param array  $args        The args for the import job (post-merge where applicable).
+	 * @param array $args The args for the import job (post-merge where applicable).
 	 * @return int Unix timestamp for when the event should run.
 	 */
-	protected static function queue_run_time( $plugin_slug, $args ) {
-		if ( self::is_trunk_only_update_on_tagged_plugin( $plugin_slug, $args ) ) {
-			return time() + 5 * MINUTE_IN_SECONDS;
+	protected static function queue_run_time( $args ) {
+		if ( self::is_trunk_only_update( $args ) ) {
+			return time() + 15 * MINUTE_IN_SECONDS;
 		}
 
 		return time() + 5;
 	}
 
 	/**
-	 * Whether an import covers only /trunk on a plugin that currently releases from a tag.
+	 * Whether an import only covers /trunk (no tags added or removed).
 	 *
-	 * @param string $plugin_slug The plugin slug.
-	 * @param array  $args        The args for the import job.
+	 * @param array $args The args for the import job.
 	 * @return bool
 	 */
-	protected static function is_trunk_only_update_on_tagged_plugin( $plugin_slug, $args ) {
+	protected static function is_trunk_only_update( $args ) {
 		$tags_touched = (array) ( $args['tags_touched'] ?? array() );
 		$tags_deleted = (array) ( $args['tags_deleted'] ?? array() );
 
-		$trunk_only = $tags_touched && array( 'trunk' ) === array_values( array_unique( $tags_touched ) ) && ! $tags_deleted;
-		if ( ! $trunk_only ) {
-			return false;
-		}
-
-		$plugin = Plugin_Directory::get_plugin_post( $plugin_slug );
-		if ( ! $plugin ) {
-			return false;
-		}
-
-		$current_stable_tag = get_post_meta( $plugin->ID, 'stable_tag', true );
-
-		return $current_stable_tag && 'trunk' !== $current_stable_tag;
+		return $tags_touched && array( 'trunk' ) === array_values( array_unique( $tags_touched ) ) && ! $tags_deleted;
 	}
 
 	/**

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-plugin-import.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-plugin-import.php
@@ -3,6 +3,7 @@ namespace WordPressdotorg\Plugin_Directory\Jobs;
 
 use Exception;
 use WordPressdotorg\Plugin_Directory\CLI;
+use WordPressdotorg\Plugin_Directory\Plugin_Directory;
 
 /**
  * Import plugin changes into WordPress.
@@ -11,38 +12,144 @@ use WordPressdotorg\Plugin_Directory\CLI;
  */
 class Plugin_Import {
 
+	/**
+	 * Queue an import job for a plugin, merging into any pending future event for the
+	 * same plugin so a single import covers all the SVN changes seen so far.
+	 *
+	 * @param string $plugin_slug The plugin slug.
+	 * @param array  $plugin_data Data about the SVN change (tags_touched, revisions, etc).
+	 */
 	public static function queue( $plugin_slug, $plugin_data ) {
+		$hook     = "import_plugin:{$plugin_slug}";
+		$new_args = array_merge( array( 'plugin' => $plugin_slug ), $plugin_data );
+
 		/*
-		 * If the next scheduled run is more than 5 minutes away (e.g. queued by a bulk
-		 * batch re-index) and no import is currently running, pull it forward to the
-		 * usual import time so a fresh commit isn't delayed behind the batch. The new
-		 * commit-driven event is then queued 1hr later via the logic below.
+		 * If there's already a future-scheduled import for this plugin and nothing
+		 * is currently running, fold the new request into it. This handles two
+		 * cases under one rule:
+		 *
+		 *  - A bulk batch re-index queued an event far in the future; a fresh
+		 *    commit should pull that forward to the usual import time.
+		 *  - A plugin that releases from a tag commits to /trunk first and then
+		 *    `svn cp trunk tags/X.Y` a moment later (see queue_run_time()). The
+		 *    first commit gets delayed; the second merges into it so a single
+		 *    import publishes the release from the tag, not from a trunk
+		 *    fallback that the tag commit then has to overwrite.
 		 */
-		$next_scheduled = Manager::get_scheduled_time( "import_plugin:{$plugin_slug}", 'next' );
-		if (
-			$next_scheduled &&
-			$next_scheduled > ( time() + 5 * MINUTE_IN_SECONDS ) &&
-			! Manager::is_event_running( "import_plugin:{$plugin_slug}" )
-		) {
-			Manager::reschedule_event( "import_plugin:{$plugin_slug}", time() + 5, $next_scheduled );
+		$next_scheduled = Manager::get_scheduled_time( $hook, 'next' );
+		if ( $next_scheduled && ! Manager::is_event_running( $hook ) ) {
+			$existing      = Manager::get_scheduled_events( $hook, $next_scheduled );
+			$existing_args = $existing[0]['args'][0] ?? array();
+			$merged_args   = self::merge_plugin_data( $existing_args, $new_args );
+
+			$updated = Manager::update_scheduled_event(
+				$hook,
+				$next_scheduled,
+				array(
+					'nextrun' => min( $next_scheduled, self::queue_run_time( $plugin_slug, $merged_args ) ),
+					'args'    => array( $merged_args ),
+				)
+			);
+
+			if ( $updated ) {
+				return;
+			}
 		}
 
-		// To avoid a situation where two imports run concurrently, if one is already scheduled or in flight, run it 1hr later (We'll trigger it after the current one finishes).
-		$when_to_run    = time() + 5;
-		$last_scheduled = Manager::get_scheduled_time( "import_plugin:{$plugin_slug}", 'last' );
+		$when_to_run = self::queue_run_time( $plugin_slug, $new_args );
+
+		// To avoid a situation where two imports run concurrently, if one is already scheduled or in flight, run it 1hr later (we'll trigger it after the current one finishes).
+		$last_scheduled = Manager::get_scheduled_time( $hook, 'last' );
 		if ( $last_scheduled ) {
 			$when_to_run = $last_scheduled + HOUR_IN_SECONDS;
-		} elseif ( Manager::is_event_running( "import_plugin:{$plugin_slug}" ) ) {
+		} elseif ( Manager::is_event_running( $hook ) ) {
 			$when_to_run = time() + HOUR_IN_SECONDS;
 		}
 
 		wp_schedule_single_event(
 			$when_to_run,
-			"import_plugin:{$plugin_slug}",
-			array(
-				array_merge( array( 'plugin' => $plugin_slug ), $plugin_data ),
-			)
+			$hook,
+			array( $new_args )
 		);
+	}
+
+	/**
+	 * Decide when an import job should run, based on the SVN changes it covers.
+	 *
+	 * Plugins that release from tags typically commit the version bump to /trunk
+	 * first and then `svn cp trunk tags/X.Y` shortly after. Running the import
+	 * immediately on the trunk commit publishes a trunk-fallback release that the
+	 * tag commit then has to overwrite as a second release. To collapse those
+	 * into one import, defer trunk-only updates by 5 minutes when the plugin is
+	 * currently releasing from a tag — that gives the follow-up tag commit time
+	 * to merge into the same job (see queue()).
+	 *
+	 * Tag-touching changes, and changes on plugins releasing from trunk, run
+	 * immediately.
+	 *
+	 * @param string $plugin_slug The plugin slug.
+	 * @param array  $args        The args for the import job (post-merge where applicable).
+	 * @return int Unix timestamp for when the event should run.
+	 */
+	protected static function queue_run_time( $plugin_slug, $args ) {
+		if ( self::is_trunk_only_update_on_tagged_plugin( $plugin_slug, $args ) ) {
+			return time() + 5 * MINUTE_IN_SECONDS;
+		}
+
+		return time() + 5;
+	}
+
+	/**
+	 * Whether an import covers only /trunk on a plugin that currently releases from a tag.
+	 *
+	 * @param string $plugin_slug The plugin slug.
+	 * @param array  $args        The args for the import job.
+	 * @return bool
+	 */
+	protected static function is_trunk_only_update_on_tagged_plugin( $plugin_slug, $args ) {
+		$tags_touched = (array) ( $args['tags_touched'] ?? array() );
+		$tags_deleted = (array) ( $args['tags_deleted'] ?? array() );
+
+		$trunk_only = $tags_touched && array( 'trunk' ) === array_values( array_unique( $tags_touched ) ) && ! $tags_deleted;
+		if ( ! $trunk_only ) {
+			return false;
+		}
+
+		$plugin = Plugin_Directory::get_plugin_post( $plugin_slug );
+		if ( ! $plugin ) {
+			return false;
+		}
+
+		$current_stable_tag = get_post_meta( $plugin->ID, 'stable_tag', true );
+
+		return $current_stable_tag && 'trunk' !== $current_stable_tag;
+	}
+
+	/**
+	 * Merge two plugin_data payloads into a single import-job payload.
+	 *
+	 * Used when folding an already-scheduled future event into a newer request so
+	 * neither set of changes is lost.
+	 *
+	 * @param array $existing The args from the currently-scheduled event.
+	 * @param array $incoming The args from the new request.
+	 * @return array Merged args ready to pass to the import job.
+	 */
+	protected static function merge_plugin_data( array $existing, array $incoming ) {
+		$merged = array_merge( $existing, $incoming );
+
+		foreach ( array( 'tags_touched', 'tags_deleted', 'revisions' ) as $key ) {
+			$existing_values = (array) ( $existing[ $key ] ?? array() );
+			$incoming_values = (array) ( $incoming[ $key ] ?? array() );
+
+			$merged[ $key ] = array_values( array_unique( array_merge( $existing_values, $incoming_values ) ) );
+		}
+
+		foreach ( array( 'readme_touched', 'code_touched', 'assets_touched' ) as $key ) {
+			$merged[ $key ] = ! empty( $existing[ $key ] ) || ! empty( $incoming[ $key ] );
+		}
+
+		return $merged;
 	}
 
 	/**

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Plugin_Import_Merge_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Plugin_Import_Merge_Test.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Tests for Plugin_Import::merge_plugin_data() and queue_run_time() helpers.
+ * Tests for Plugin_Import::merge_plugin_data() and is_trunk_only_update() helpers.
  *
  * @package WordPressdotorg\Plugin_Directory\Tests
  */
@@ -24,13 +24,13 @@ class Plugin_Import_Merge_Test extends TestCase {
 	}
 
 	/**
-	 * Invoke the protected Plugin_Import::is_trunk_only_update_on_tagged_plugin() helper.
+	 * Invoke the protected Plugin_Import::is_trunk_only_update() helper.
 	 */
-	private function is_trunk_only_on_tagged_plugin( string $plugin_slug, array $args ): bool {
-		$method = new ReflectionMethod( Plugin_Import::class, 'is_trunk_only_update_on_tagged_plugin' );
+	private function is_trunk_only( array $args ): bool {
+		$method = new ReflectionMethod( Plugin_Import::class, 'is_trunk_only_update' );
 		$method->setAccessible( true );
 
-		return $method->invoke( null, $plugin_slug, $args );
+		return $method->invoke( null, $args );
 	}
 
 	public function test_merges_revisions_and_tags_without_duplicates() {
@@ -97,40 +97,49 @@ class Plugin_Import_Merge_Test extends TestCase {
 	}
 
 	/**
+	 * A commit that touches only /trunk is the candidate for the grace window.
+	 */
+	public function test_trunk_only_commit_is_classified_as_trunk_only() {
+		$this->assertTrue( $this->is_trunk_only( [
+			'tags_touched' => [ 'trunk' ],
+			'tags_deleted' => [],
+		] ) );
+	}
+
+	/**
 	 * If a tag is touched the change should never be classified as trunk-only,
 	 * even if /trunk is also in the same commit.
 	 */
 	public function test_change_touching_a_tag_is_not_trunk_only() {
-		$this->assertFalse( $this->is_trunk_only_on_tagged_plugin( 'no-such-plugin', [
+		$this->assertFalse( $this->is_trunk_only( [
 			'tags_touched' => [ 'trunk', '1.2.3' ],
 			'tags_deleted' => [],
 		] ) );
 
-		$this->assertFalse( $this->is_trunk_only_on_tagged_plugin( 'no-such-plugin', [
+		$this->assertFalse( $this->is_trunk_only( [
 			'tags_touched' => [ '1.2.3' ],
 			'tags_deleted' => [],
 		] ) );
 	}
 
 	/**
-	 * A change that deletes a tag isn't a candidate for the 5-minute delay either:
-	 * the deletion needs to propagate to the directory immediately.
+	 * A change that deletes a tag isn't a candidate for the grace window
+	 * either: the deletion needs to propagate to the directory immediately.
 	 */
 	public function test_change_deleting_a_tag_is_not_trunk_only() {
-		$this->assertFalse( $this->is_trunk_only_on_tagged_plugin( 'no-such-plugin', [
+		$this->assertFalse( $this->is_trunk_only( [
 			'tags_touched' => [ 'trunk' ],
 			'tags_deleted' => [ '1.1.0' ],
 		] ) );
 	}
 
 	/**
-	 * Without a backing plugin post the helper falls back to "run immediately",
-	 * so the import isn't held up just because the directory hasn't seen the
-	 * plugin yet.
+	 * An empty set of touched tags (a defensive default) shouldn't be
+	 * misclassified as a delayable trunk-only update.
 	 */
-	public function test_unknown_plugin_does_not_delay() {
-		$this->assertFalse( $this->is_trunk_only_on_tagged_plugin( 'no-such-plugin', [
-			'tags_touched' => [ 'trunk' ],
+	public function test_empty_tags_touched_is_not_trunk_only() {
+		$this->assertFalse( $this->is_trunk_only( [
+			'tags_touched' => [],
 			'tags_deleted' => [],
 		] ) );
 	}

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Plugin_Import_Merge_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Plugin_Import_Merge_Test.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * Tests for Plugin_Import::merge_plugin_data() and queue_run_time() helpers.
+ *
+ * @package WordPressdotorg\Plugin_Directory\Tests
+ */
+
+use PHPUnit\Framework\TestCase;
+use WordPressdotorg\Plugin_Directory\Jobs\Plugin_Import;
+
+/**
+ * @group jobs
+ */
+class Plugin_Import_Merge_Test extends TestCase {
+
+	/**
+	 * Invoke the protected Plugin_Import::merge_plugin_data() helper.
+	 */
+	private function merge( array $existing, array $incoming ): array {
+		$method = new ReflectionMethod( Plugin_Import::class, 'merge_plugin_data' );
+		$method->setAccessible( true );
+
+		return $method->invoke( null, $existing, $incoming );
+	}
+
+	/**
+	 * Invoke the protected Plugin_Import::is_trunk_only_update_on_tagged_plugin() helper.
+	 */
+	private function is_trunk_only_on_tagged_plugin( string $plugin_slug, array $args ): bool {
+		$method = new ReflectionMethod( Plugin_Import::class, 'is_trunk_only_update_on_tagged_plugin' );
+		$method->setAccessible( true );
+
+		return $method->invoke( null, $plugin_slug, $args );
+	}
+
+	public function test_merges_revisions_and_tags_without_duplicates() {
+		$existing = [
+			'plugin'         => 'hello',
+			'tags_touched'   => [ 'trunk', '1.0' ],
+			'tags_deleted'   => [],
+			'revisions'      => [ 100, 101 ],
+			'readme_touched' => true,
+			'code_touched'   => false,
+			'assets_touched' => false,
+		];
+		$new = [
+			'plugin'         => 'hello',
+			'tags_touched'   => [ 'trunk', '2.0' ],
+			'tags_deleted'   => [ '0.9' ],
+			'revisions'      => [ 101, 200 ],
+			'readme_touched' => false,
+			'code_touched'   => true,
+			'assets_touched' => false,
+		];
+
+		$merged = $this->merge( $existing, $new );
+
+		$this->assertEqualsCanonicalizing( [ 'trunk', '1.0', '2.0' ], $merged['tags_touched'] );
+		$this->assertEqualsCanonicalizing( [ '0.9' ], $merged['tags_deleted'] );
+		$this->assertEqualsCanonicalizing( [ 100, 101, 200 ], $merged['revisions'] );
+	}
+
+	public function test_boolean_flags_are_ored() {
+		$existing = [
+			'readme_touched' => true,
+			'code_touched'   => false,
+			'assets_touched' => false,
+		];
+		$new = [
+			'readme_touched' => false,
+			'code_touched'   => true,
+			'assets_touched' => false,
+		];
+
+		$merged = $this->merge( $existing, $new );
+
+		$this->assertTrue( $merged['readme_touched'] );
+		$this->assertTrue( $merged['code_touched'] );
+		$this->assertFalse( $merged['assets_touched'] );
+	}
+
+	public function test_missing_keys_in_existing_are_safe() {
+		$merged = $this->merge(
+			[ 'plugin' => 'hello' ],
+			[
+				'plugin'         => 'hello',
+				'tags_touched'   => [ 'trunk' ],
+				'revisions'      => [ 42 ],
+				'readme_touched' => true,
+			]
+		);
+
+		$this->assertSame( [ 'trunk' ], $merged['tags_touched'] );
+		$this->assertSame( [ 42 ], $merged['revisions'] );
+		$this->assertSame( [], $merged['tags_deleted'] );
+		$this->assertTrue( $merged['readme_touched'] );
+	}
+
+	/**
+	 * If a tag is touched the change should never be classified as trunk-only,
+	 * even if /trunk is also in the same commit.
+	 */
+	public function test_change_touching_a_tag_is_not_trunk_only() {
+		$this->assertFalse( $this->is_trunk_only_on_tagged_plugin( 'no-such-plugin', [
+			'tags_touched' => [ 'trunk', '1.2.3' ],
+			'tags_deleted' => [],
+		] ) );
+
+		$this->assertFalse( $this->is_trunk_only_on_tagged_plugin( 'no-such-plugin', [
+			'tags_touched' => [ '1.2.3' ],
+			'tags_deleted' => [],
+		] ) );
+	}
+
+	/**
+	 * A change that deletes a tag isn't a candidate for the 5-minute delay either:
+	 * the deletion needs to propagate to the directory immediately.
+	 */
+	public function test_change_deleting_a_tag_is_not_trunk_only() {
+		$this->assertFalse( $this->is_trunk_only_on_tagged_plugin( 'no-such-plugin', [
+			'tags_touched' => [ 'trunk' ],
+			'tags_deleted' => [ '1.1.0' ],
+		] ) );
+	}
+
+	/**
+	 * Without a backing plugin post the helper falls back to "run immediately",
+	 * so the import isn't held up just because the directory hasn't seen the
+	 * plugin yet.
+	 */
+	public function test_unknown_plugin_does_not_delay() {
+		$this->assertFalse( $this->is_trunk_only_on_tagged_plugin( 'no-such-plugin', [
+			'tags_touched' => [ 'trunk' ],
+			'tags_deleted' => [],
+		] ) );
+	}
+}


### PR DESCRIPTION
Stacks on top of WordPress/wordpress.org#631 to address the trunk-then-tag double-import problem.

## The problem

Plugins that release from a tag commonly commit the version-bumped files to `/trunk` first and then `svn cp trunk tags/X.Y` shortly after — see r3530799 / r3530800 for a recent real-world example. Today the SVN watcher imports the trunk commit immediately: trunks `Stable Tag` points at the new version but `/tags/X.Y` does not exist yet, so the importer falls back to publishing the release from trunk (with the `stable_tag_invalid_trunk_fallback` warning). The follow-up tag commit then triggers a second import that re-publishes the same release from the tag.

## The change

Reuses the merge model that this PR started with but expands it to cover this case. `Plugin_Import::queue()` now:

1. If a future event already exists for the plugin and no job is running, **merge** the new args into it (restoring `merge_plugin_data()` and the per-key OR/union behavior).
2. Decide the events run time from the **merged** args via a new `queue_run_time()` helper. **Trunk-only updates** (no tag added or deleted) wait `15 * MINUTE_IN_SECONDS`. Anything that touches a tag — additions or deletions — runs in `5s`.
3. Use `min( existing_nextrun, queue_run_time(merged) )` so a pending event is never pushed further out.

That collapses two previously-separate rules into one:

- **Bulk re-index pull-forward** (this PRs current behavior): a far-future event merges with an arriving commit and runs at the usual time. Same outcome as before, just expressed as a merge.
- **Trunk grace window** (new): every trunk-only commit schedules `now + 15min`, giving the author room to land the follow-up `svn cp trunk tags/X.Y`. If that tag commit arrives within the window, it merges in — the merged args are no longer trunk-only, so `queue_run_time()` returns `now + 5s` and the event pulls forward to run as a single import that publishes from the tag. If no tag arrives, the event runs as scheduled and publishes from trunk-fallback, same as today (but only once).

## Why a blanket trunk delay (rather than gating on `stable_tag != trunk`)

Previous revision of this PR only delayed when the plugins current `stable_tag` was already a versioned tag, on the theory that "this plugin probably tags." Switched to delaying every trunk-only import because:

- A plugin can switch to tagging at any point — delay-only-if-tagged-before would still miss the first tagged release after a trunk-only history.
- The cost is small: a trunk-only import that doesnt receive a follow-up tag still runs after 15 min and produces the same result it produces today. A trunk-only commit that doesnt bump `Stable Tag` (eg a bugfix) just runs late and effectively no-ops.
- Drops the post lookup and `get_post_meta()` from the queue path — its now pure data on the args.

## Edge cases

- Tag-touching changes, tag deletions, and any commit with mixed trunk + tag touches run immediately — no behavior change.
- Brand-new plugin imports go through `Status_Transitions::approved_create_svn_repo()`, not this queue path; unaffected.
- Manual triggers via `bin/import-plugin.php` call `cron_trigger` directly; unaffected.
- Running-job concurrency guard (`last_scheduled + 1hr`, or `now + 1hr` if a job is in flight) is preserved.

## Changes

- `Plugin_Import::queue()` — unified merge model.
- `Plugin_Import::queue_run_time()` + `Plugin_Import::is_trunk_only_update()` — new run-time decision (pure-data, no DB lookups).
- `Plugin_Import::merge_plugin_data()` — restored from earlier in this PR.
- `tests/Plugin_Import_Merge_Test.php` — restored and expanded with classification cases.

## Test plan

- [ ] `npm run plugins:test --filter Plugin_Import_Merge_Test` — all merge + classification tests pass.
- [ ] In staging: commit a trunk-only change to any plugin → event is scheduled `~now + 15min`. Within the window, commit `svn cp trunk tags/1.1` → events args now include the tag and its `nextrun` is `~now + 5s`. A single import runs and publishes from `tags/1.1`.
- [ ] In staging: commit a tag (or a tag deletion) directly → event scheduled `~now + 5s` (no delay).
- [ ] In staging: with a bulk re-index event already queued 30 min out, trigger a commit-driven `queue()` → event pulled forward to the appropriate `queue_run_time` and args merged (PR-631 behavior, unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)